### PR TITLE
fix std::atomic_bool for msvc2013

### DIFF
--- a/includes/tacopie/network/io_service.hpp
+++ b/includes/tacopie/network/io_service.hpp
@@ -79,10 +79,10 @@ private:
     //! ctor
     tracked_socket(void)
     : rd_callback(nullptr)
-    , is_executing_rd_callback(false)
+    , is_executing_rd_callback(ATOMIC_VAR_INIT(false))
     , wr_callback(nullptr)
-    , is_executing_wr_callback(false)
-    , marked_for_untrack(false) {}
+    , is_executing_wr_callback(ATOMIC_VAR_INIT(false))
+    , marked_for_untrack(ATOMIC_VAR_INIT(false)) {}
 
     //! rd event
     event_callback_t rd_callback;

--- a/sources/network/tcp_client.cpp
+++ b/sources/network/tcp_client.cpp
@@ -32,7 +32,7 @@ namespace tacopie {
 
 tcp_client::tcp_client(void)
 : m_io_service(get_default_io_service())
-, m_is_connected(false)
+, m_is_connected(ATOMIC_VAR_INIT(false))
 , m_disconnection_handler(nullptr) { __TACOPIE_LOG(debug, "create tcp_client"); }
 
 tcp_client::~tcp_client(void) {
@@ -48,7 +48,7 @@ tcp_client::~tcp_client(void) {
 tcp_client::tcp_client(tcp_socket&& socket)
 : m_io_service(get_default_io_service())
 , m_socket(std::move(socket))
-, m_is_connected(true)
+, m_is_connected(ATOMIC_VAR_INIT(true))
 , m_disconnection_handler(nullptr) {
   __TACOPIE_LOG(debug, "create tcp_client");
   m_io_service->track(m_socket);

--- a/sources/network/tcp_server.cpp
+++ b/sources/network/tcp_server.cpp
@@ -34,7 +34,7 @@ namespace tacopie {
 
 tcp_server::tcp_server(void)
 : m_io_service(get_default_io_service())
-, m_is_running(false)
+, m_is_running(ATOMIC_VAR_INIT(false))
 , m_on_new_connection_callback(nullptr) { __TACOPIE_LOG(debug, "create tcp_server"); }
 
 tcp_server::~tcp_server(void) {

--- a/sources/network/windows/io_service.cpp
+++ b/sources/network/windows/io_service.cpp
@@ -58,7 +58,7 @@ set_default_io_service(const std::shared_ptr<io_service>& service) {
 //!
 
 io_service::io_service(void)
-: m_should_stop(false)
+: m_should_stop(ATOMIC_VAR_INIT(false))
 , m_callback_workers(__TACOPIE_IO_SERVICE_NB_WORKERS) {
   __TACOPIE_LOG(debug, "create io_service");
 

--- a/sources/utils/thread_pool.cpp
+++ b/sources/utils/thread_pool.cpp
@@ -32,7 +32,7 @@ namespace utils {
 //!
 
 thread_pool::thread_pool(std::size_t nb_threads)
-: m_should_stop(false) {
+: m_should_stop(ATOMIC_VAR_INIT(false)) {
   __TACOPIE_LOG(debug, "create thread_pool");
 
   for (std::size_t i = 0; i < nb_threads; ++i) { m_workers.push_back(std::thread(std::bind(&thread_pool::run, this))); }


### PR DESCRIPTION
As discussed on [cpp_redis](https://github.com/Cylix/cpp_redis) repository ([issue 37](https://github.com/Cylix/cpp_redis/issues/37)) this should fix the errors related to std::atomic_bool.