### PR TITLE
Fix std::atomic compilation errors (C2797) on msvc 2013 (again)

### DIFF
--- a/includes/tacopie/network/io_service.hpp
+++ b/includes/tacopie/network/io_service.hpp
@@ -83,14 +83,14 @@ private:
 
     //! rd event
     event_callback_t rd_callback;
-    std::atomic_bool is_executing_rd_callback = ATOMIC_VAR_INIT(false);
+    std::atomic<bool> is_executing_rd_callback = ATOMIC_VAR_INIT(false);
 
     //! wr event
     event_callback_t wr_callback;
-    std::atomic_bool is_executing_wr_callback = ATOMIC_VAR_INIT(false);
+    std::atomic<bool> is_executing_wr_callback = ATOMIC_VAR_INIT(false);
 
     //! marked for untrack
-    std::atomic_bool marked_for_untrack = ATOMIC_VAR_INIT(false);
+    std::atomic<bool> marked_for_untrack = ATOMIC_VAR_INIT(false);
   };
 
 private:
@@ -110,7 +110,7 @@ private:
   std::unordered_map<fd_t, tracked_socket> m_tracked_sockets;
 
   //! whether the worker should stop or not
-  std::atomic_bool m_should_stop;
+  std::atomic<bool> m_should_stop;
 
   //! poll thread
   std::thread m_poll_worker;

--- a/includes/tacopie/network/tcp_client.hpp
+++ b/includes/tacopie/network/tcp_client.hpp
@@ -134,7 +134,7 @@ private:
   tacopie::tcp_socket m_socket;
 
   //! whether the client is currently connected or not
-  std::atomic_bool m_is_connected = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> m_is_connected = ATOMIC_VAR_INIT(false);
 
   //! read & write requests
   std::queue<read_request> m_read_requests;

--- a/includes/tacopie/network/tcp_server.hpp
+++ b/includes/tacopie/network/tcp_server.hpp
@@ -89,7 +89,7 @@ private:
   tacopie::tcp_socket m_socket;
 
   //! whether the server is currently running or not
-  std::atomic_bool m_is_running = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> m_is_running = ATOMIC_VAR_INIT(false);
 
   //! clients
   std::list<std::shared_ptr<tacopie::tcp_client>> m_clients;

--- a/includes/tacopie/utils/thread_pool.hpp
+++ b/includes/tacopie/utils/thread_pool.hpp
@@ -70,7 +70,7 @@ private:
   std::vector<std::thread> m_workers;
 
   //! whether the thread_pool should stop or not
-  std::atomic_bool m_should_stop = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> m_should_stop = ATOMIC_VAR_INIT(false);
 
   //! tasks
   std::queue<task_t> m_tasks;


### PR DESCRIPTION
I think this will be the best fix for this (painful) issue.

Consider the following example:
```cpp
class SomeClass
{
	std::atomic_bool test1 = ATOMIC_VAR_INIT(false);	// Fails on VS 2013 (C2797)
	std::atomic<bool> test2 = ATOMIC_VAR_INIT(false);	// Works on VS 2013 and VS 2015
};
```

VS 2015 defines `atomic_bool` type on `atomic` header like this:
```cpp
// ATOMIC TYPEDEFS
typedef atomic<bool> atomic_bool;
```

So using fully specialized templates will help in this case.
This will work on both versions and don't thrown any warning on osx + clang.

I have tested this against Visual Studio 2013 Update 5 and Visual Studio 2015 Update 3, both are building fine.

Seems that atomic_bool was a bet for C language, but as this is a C++ library I don't think this change will be an issue.

For further reference:
http://comp.std.cpp.narkive.com/nwMakWji/std-atomic-bool-vs-std-atomic-bool

PS: I'll do the same for cpp_redis.