### PR TITLE
Remove explicit STATIC in add_library call so dynamic libraries can be built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 ###
 # executable
 ###
-add_library(${PROJECT} STATIC ${SOURCES})
+add_library(${PROJECT} ${SOURCES})
 
 IF (WIN32)
    set_target_properties(${PROJECT}


### PR DESCRIPTION
Should default to `STATIC`, and if shared libraries are desired, use the  `-DBUILD_SHARED_LIBS=ON` cmake option